### PR TITLE
Add search to kitty-pager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,7 +780,6 @@ dependencies = [
  "syntect",
  "tempfile",
  "terminal_size",
- "tiny-skia 0.12.0",
  "ureq",
 ]
 
@@ -1101,7 +1100,7 @@ dependencies = [
  "pico-args",
  "rgb",
  "svgtypes",
- "tiny-skia 0.11.4",
+ "tiny-skia",
  "usvg",
  "zune-jpeg 0.4.21",
 ]
@@ -1552,22 +1551,7 @@ dependencies = [
  "cfg-if",
  "log",
  "png 0.17.16",
- "tiny-skia-path 0.11.4",
-]
-
-[[package]]
-name = "tiny-skia"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47ffee5eaaf5527f630fb0e356b90ebdec84d5d18d937c5e440350f88c5a91ea"
-dependencies = [
- "arrayref",
- "arrayvec",
- "bytemuck",
- "cfg-if",
- "log",
- "png 0.18.1",
- "tiny-skia-path 0.12.0",
+ "tiny-skia-path",
 ]
 
 [[package]]
@@ -1735,7 +1719,7 @@ dependencies = [
  "siphasher",
  "strict-num",
  "svgtypes",
- "tiny-skia-path 0.11.4",
+ "tiny-skia-path",
  "unicode-bidi",
  "unicode-script",
  "unicode-vo",

--- a/kitty-pager/src/input.rs
+++ b/kitty-pager/src/input.rs
@@ -9,8 +9,79 @@ use crossterm::{
 };
 
 use crate::document::KittyDocument;
-use crate::renderer::{layout, render_frame};
+use crate::renderer::{layout, render_frame, strip_ansi, EntryKind, LayoutEntry};
 use crate::PagerOptions;
+
+// ── Search types ─────────────────────────────────────────────────────────────
+
+#[derive(Clone, Copy, PartialEq)]
+enum SearchDirection {
+    Forward,
+    Backward,
+}
+
+struct SearchState {
+    query: String,
+    /// Sorted layout-entry indices whose plain text contains the query.
+    matches: Vec<usize>,
+    /// Current position within `matches`.
+    current: usize,
+}
+
+enum InputMode {
+    Normal,
+    SearchInput {
+        buffer: String,
+        direction: SearchDirection,
+    },
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Return the layout-entry indices (in order) whose text contains `query`
+/// (case-insensitive).  Image rows are never matched.
+fn find_matches(entries: &[LayoutEntry], query: &str) -> Vec<usize> {
+    if query.is_empty() {
+        return Vec::new();
+    }
+    let lower = query.to_lowercase();
+    entries
+        .iter()
+        .enumerate()
+        .filter_map(|(i, entry)| {
+            if let EntryKind::Text(line) = &entry.kind {
+                if strip_ansi(line).to_lowercase().contains(&lower) {
+                    Some(i)
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// Build the string to append to the status bar based on the current mode and
+/// search state.  Empty string means nothing extra is shown.
+fn status_suffix(mode: &InputMode, search: &Option<SearchState>) -> String {
+    match mode {
+        InputMode::SearchInput { buffer, direction } => {
+            let prefix = match direction {
+                SearchDirection::Forward => '/',
+                SearchDirection::Backward => '?',
+            };
+            format!("{prefix}{buffer}_")
+        }
+        InputMode::Normal => match search {
+            Some(s) if s.matches.is_empty() => format!("/{} [No matches]", s.query),
+            Some(s) => format!("/{} [{}/{}]", s.query, s.current + 1, s.matches.len()),
+            None => String::new(),
+        },
+    }
+}
+
+// ── Public entry point ────────────────────────────────────────────────────────
 
 /// Run the interactive pager event loop.
 pub(crate) fn run_pager(doc: &KittyDocument, opts: &PagerOptions) -> Result<()> {
@@ -37,9 +108,11 @@ pub(crate) fn run_pager(doc: &KittyDocument, opts: &PagerOptions) -> Result<()> 
     result
 }
 
+// ── Event loop ────────────────────────────────────────────────────────────────
+
 fn event_loop(
     doc: &KittyDocument,
-    entries: &mut Vec<crate::renderer::LayoutEntry>,
+    entries: &mut Vec<LayoutEntry>,
     opts: &PagerOptions,
     stdout: &mut impl Write,
 ) -> Result<()> {
@@ -48,53 +121,148 @@ fn event_loop(
     let mut screen_rows = opts.term_height;
     let cell_w = opts.cell_pixel_width.max(1);
     let cell_h = opts.cell_pixel_height.max(1);
+    let mut mode = InputMode::Normal;
+    let mut search: Option<SearchState> = None;
 
-    let frame = render_frame(doc, entries, top_entry, screen_rows, cell_w, cell_h, &mut transmitted);
-    write!(stdout, "{}", frame)?;
-    stdout.flush()?;
+    // Initial render.
+    {
+        let sq = search.as_ref().map_or("", |s| s.query.as_str());
+        let st = status_suffix(&mode, &search);
+        let frame = render_frame(doc, entries, top_entry, screen_rows, cell_w, cell_h, &mut transmitted, sq, &st);
+        write!(stdout, "{}", frame)?;
+        stdout.flush()?;
+    }
 
     loop {
         match event::read()? {
             Event::Key(KeyEvent { code, modifiers, .. }) => {
-                let max_top = entries.len().saturating_sub(1);
-                let half_page = (screen_rows as usize).saturating_sub(2).max(1) / 2;
-                let full_page = (screen_rows as usize).saturating_sub(2).max(1);
+                match mode {
+                    // ── Search-input mode: capture the query string ──────────
+                    InputMode::SearchInput { ref mut buffer, direction } => {
+                        match code {
+                            KeyCode::Esc => {
+                                mode = InputMode::Normal;
+                            }
+                            KeyCode::Enter => {
+                                let query = buffer.clone();
+                                let matches = find_matches(entries, &query);
+                                let current = if matches.is_empty() {
+                                    0
+                                } else {
+                                    match direction {
+                                        SearchDirection::Forward => matches
+                                            .iter()
+                                            .position(|&m| m >= top_entry)
+                                            .unwrap_or(0),
+                                        SearchDirection::Backward => matches
+                                            .iter()
+                                            .rposition(|&m| m <= top_entry)
+                                            .unwrap_or(matches.len() - 1),
+                                    }
+                                };
+                                if !matches.is_empty() {
+                                    top_entry = matches[current];
+                                }
+                                search = Some(SearchState { query, matches, current });
+                                mode = InputMode::Normal;
+                            }
+                            KeyCode::Backspace => {
+                                buffer.pop();
+                            }
+                            KeyCode::Char(c)
+                                if modifiers == KeyModifiers::NONE
+                                    || modifiers == KeyModifiers::SHIFT =>
+                            {
+                                buffer.push(c);
+                            }
+                            _ => continue,
+                        }
+                    }
 
-                match (code, modifiers) {
-                    (KeyCode::Char('q'), _)
-                    | (KeyCode::Char('Q'), _)
-                    | (KeyCode::Esc, _)
-                    | (KeyCode::Char('c'), KeyModifiers::CONTROL) => break,
+                    // ── Normal mode: scrolling, search initiation, quit ──────
+                    InputMode::Normal => {
+                        let max_top = entries.len().saturating_sub(1);
+                        let half_page = (screen_rows as usize).saturating_sub(2).max(1) / 2;
+                        let full_page = (screen_rows as usize).saturating_sub(2).max(1);
 
-                    (KeyCode::Char('j'), _) | (KeyCode::Down, _) => {
-                        top_entry = (top_entry + 1).min(max_top);
+                        match (code, modifiers) {
+                            (KeyCode::Char('q'), _)
+                            | (KeyCode::Char('Q'), _)
+                            | (KeyCode::Esc, _)
+                            | (KeyCode::Char('c'), KeyModifiers::CONTROL) => break,
+
+                            // Search initiation
+                            (KeyCode::Char('/'), _) => {
+                                mode = InputMode::SearchInput {
+                                    buffer: String::new(),
+                                    direction: SearchDirection::Forward,
+                                };
+                            }
+                            (KeyCode::Char('?'), _) => {
+                                mode = InputMode::SearchInput {
+                                    buffer: String::new(),
+                                    direction: SearchDirection::Backward,
+                                };
+                            }
+
+                            // Search navigation
+                            (KeyCode::Char('n'), _) => {
+                                if let Some(ref mut s) = search {
+                                    if !s.matches.is_empty() {
+                                        s.current = (s.current + 1) % s.matches.len();
+                                        top_entry = s.matches[s.current];
+                                    }
+                                } else {
+                                    continue;
+                                }
+                            }
+                            (KeyCode::Char('N'), _) => {
+                                if let Some(ref mut s) = search {
+                                    if !s.matches.is_empty() {
+                                        s.current = s.current.checked_sub(1).unwrap_or(s.matches.len() - 1);
+                                        top_entry = s.matches[s.current];
+                                    }
+                                } else {
+                                    continue;
+                                }
+                            }
+
+                            // Scrolling
+                            (KeyCode::Char('j'), _) | (KeyCode::Down, _) => {
+                                top_entry = (top_entry + 1).min(max_top);
+                            }
+                            (KeyCode::Char('k'), _) | (KeyCode::Up, _) => {
+                                top_entry = top_entry.saturating_sub(1);
+                            }
+                            (KeyCode::Char('d'), KeyModifiers::CONTROL) => {
+                                top_entry = (top_entry + half_page).min(max_top);
+                            }
+                            (KeyCode::Char('b'), KeyModifiers::CONTROL) => {
+                                top_entry = top_entry.saturating_sub(half_page);
+                            }
+                            (KeyCode::PageDown, _) => {
+                                top_entry = (top_entry + full_page).min(max_top);
+                            }
+                            (KeyCode::PageUp, _) => {
+                                top_entry = top_entry.saturating_sub(full_page);
+                            }
+                            (KeyCode::Home, _) | (KeyCode::Char('g'), _) => {
+                                top_entry = 0;
+                            }
+                            (KeyCode::End, _) | (KeyCode::Char('G'), _) => {
+                                top_entry = max_top;
+                            }
+
+                            _ => continue,
+                        }
                     }
-                    (KeyCode::Char('k'), _) | (KeyCode::Up, _) => {
-                        top_entry = top_entry.saturating_sub(1);
-                    }
-                    (KeyCode::Char('d'), KeyModifiers::CONTROL) => {
-                        top_entry = (top_entry + half_page).min(max_top);
-                    }
-                    (KeyCode::Char('b'), KeyModifiers::CONTROL) => {
-                        top_entry = top_entry.saturating_sub(half_page);
-                    }
-                    (KeyCode::PageDown, _) => {
-                        top_entry = (top_entry + full_page).min(max_top);
-                    }
-                    (KeyCode::PageUp, _) => {
-                        top_entry = top_entry.saturating_sub(full_page);
-                    }
-                    (KeyCode::Home, _) | (KeyCode::Char('g'), _) => {
-                        top_entry = 0;
-                    }
-                    (KeyCode::End, _) | (KeyCode::Char('G'), _) => {
-                        top_entry = max_top;
-                    }
-                    _ => continue,
                 }
 
+                // Re-render after any handled key.
+                let sq = search.as_ref().map_or("", |s| s.query.as_str());
+                let st = status_suffix(&mode, &search);
                 let frame = render_frame(
-                    doc, entries, top_entry, screen_rows, cell_w, cell_h, &mut transmitted,
+                    doc, entries, top_entry, screen_rows, cell_w, cell_h, &mut transmitted, sq, &st,
                 );
                 write!(stdout, "{}", frame)?;
                 stdout.flush()?;
@@ -105,9 +273,18 @@ fn event_loop(
                 *entries = layout(doc, cell_w, cell_h);
                 let max_top = entries.len().saturating_sub(1);
                 top_entry = top_entry.min(max_top);
+                // Re-run search on new layout so match indices stay valid.
+                if let Some(ref mut s) = search {
+                    s.matches = find_matches(entries, &s.query);
+                    if !s.matches.is_empty() {
+                        s.current = s.current.min(s.matches.len() - 1);
+                    }
+                }
 
+                let sq = search.as_ref().map_or("", |s| s.query.as_str());
+                let st = status_suffix(&mode, &search);
                 let frame = render_frame(
-                    doc, entries, top_entry, screen_rows, cell_w, cell_h, &mut transmitted,
+                    doc, entries, top_entry, screen_rows, cell_w, cell_h, &mut transmitted, sq, &st,
                 );
                 write!(stdout, "{}", frame)?;
                 stdout.flush()?;
@@ -118,4 +295,110 @@ fn event_loop(
     }
 
     Ok(())
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::document::{DocItem, KittyDocument, KittyImage};
+    use crate::renderer::layout;
+
+    fn text_doc(text: &str) -> KittyDocument {
+        KittyDocument { items: vec![DocItem::Text(text.to_string())] }
+    }
+
+    fn image_doc() -> KittyDocument {
+        KittyDocument {
+            items: vec![DocItem::Image(KittyImage {
+                id: 1,
+                rgba_data: vec![0u8; 4 * 8 * 8],
+                pixel_width: 8,
+                pixel_height: 8,
+                display_cols: None,
+            })],
+        }
+    }
+
+    #[test]
+    fn find_matches_text_entries() {
+        let doc = text_doc("hello world\nfoo bar\nhello again");
+        let entries = layout(&doc, 8, 16);
+        let matches = find_matches(&entries, "hello");
+        assert_eq!(matches, vec![0, 2]);
+    }
+
+    #[test]
+    fn find_matches_ignores_images() {
+        let doc = image_doc();
+        let entries = layout(&doc, 8, 16);
+        let matches = find_matches(&entries, "anything");
+        assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn find_matches_case_insensitive() {
+        let doc = text_doc("Hello World");
+        let entries = layout(&doc, 8, 16);
+        assert!(!find_matches(&entries, "hello").is_empty());
+        assert!(!find_matches(&entries, "WORLD").is_empty());
+    }
+
+    #[test]
+    fn find_matches_no_match() {
+        let doc = text_doc("foo bar");
+        let entries = layout(&doc, 8, 16);
+        assert!(find_matches(&entries, "xyz").is_empty());
+    }
+
+    #[test]
+    fn find_matches_empty_query_returns_empty() {
+        let doc = text_doc("foo bar");
+        let entries = layout(&doc, 8, 16);
+        assert!(find_matches(&entries, "").is_empty());
+    }
+
+    #[test]
+    fn status_suffix_search_input_forward() {
+        let mode = InputMode::SearchInput {
+            buffer: "foo".to_string(),
+            direction: SearchDirection::Forward,
+        };
+        assert_eq!(status_suffix(&mode, &None), "/foo_");
+    }
+
+    #[test]
+    fn status_suffix_search_input_backward() {
+        let mode = InputMode::SearchInput {
+            buffer: "bar".to_string(),
+            direction: SearchDirection::Backward,
+        };
+        assert_eq!(status_suffix(&mode, &None), "?bar_");
+    }
+
+    #[test]
+    fn status_suffix_normal_with_matches() {
+        let search = Some(SearchState {
+            query: "foo".to_string(),
+            matches: vec![0, 5, 10],
+            current: 1,
+        });
+        assert_eq!(status_suffix(&InputMode::Normal, &search), "/foo [2/3]");
+    }
+
+    #[test]
+    fn status_suffix_normal_no_matches() {
+        let search = Some(SearchState {
+            query: "xyz".to_string(),
+            matches: vec![],
+            current: 0,
+        });
+        assert_eq!(status_suffix(&InputMode::Normal, &search), "/xyz [No matches]");
+    }
+
+    #[test]
+    fn status_suffix_normal_no_search() {
+        assert_eq!(status_suffix(&InputMode::Normal, &None), "");
+    }
 }

--- a/kitty-pager/src/renderer.rs
+++ b/kitty-pager/src/renderer.rs
@@ -21,6 +21,44 @@ pub(crate) enum EntryKind {
     },
 }
 
+/// Strip ANSI escape sequences (CSI and APC/OSC/PM) from `s`, returning plain text.
+pub(crate) fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\x1b' {
+            match chars.next() {
+                Some('[') => {
+                    // CSI sequence: skip until a final byte (ASCII 0x40–0x7E).
+                    for c2 in chars.by_ref() {
+                        if ('\x40'..='\x7e').contains(&c2) {
+                            break;
+                        }
+                    }
+                }
+                Some(intro @ ('_' | ']' | '^' | 'P')) => {
+                    // APC / OSC / PM / DCS: skip until String Terminator (\x1b\\) or BEL.
+                    let _ = intro;
+                    loop {
+                        match chars.next() {
+                            Some('\x1b') => {
+                                chars.next(); // consume '\\'
+                                break;
+                            }
+                            Some('\x07') | None => break,
+                            _ => {}
+                        }
+                    }
+                }
+                _ => {}
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
 /// Build a flat list of terminal rows from a document.
 ///
 /// Text items are split on `\n`; each line becomes one `LayoutEntry`.
@@ -78,6 +116,12 @@ pub(crate) fn layout(doc: &KittyDocument, cell_px_width: u32, cell_px_height: u3
 /// Images are placed with source-rectangle cropping (`y=`, `r=`) so that
 /// partially-visible images render correctly when scrolled.  Pixel data is
 /// transmitted once (`a=T`) and re-placed cheaply (`a=p`) on subsequent frames.
+///
+/// `search_query`: when non-empty, text lines whose plain content contains the
+/// query (case-insensitive) are rendered with reverse-video highlighting.
+///
+/// `status_text`: appended to the status bar.  Pass the search prompt during
+/// input mode, the active query indicator in normal mode, or an empty string.
 pub(crate) fn render_frame(
     doc: &KittyDocument,
     layout: &[LayoutEntry],
@@ -86,6 +130,8 @@ pub(crate) fn render_frame(
     cell_px_width: u32,
     cell_px_height: u32,
     transmitted: &mut HashSet<u32>,
+    search_query: &str,
+    status_text: &str,
 ) -> String {
     let mut out = String::new();
 
@@ -99,6 +145,7 @@ pub(crate) fn render_frame(
     // Track which images have already been placed in this frame so we skip
     // their continuation rows.
     let mut placed_images: HashSet<usize> = HashSet::new();
+    let query_lower = search_query.to_lowercase();
 
     for entry in layout.iter().skip(top_entry) {
         if rows_rendered >= max_content_rows {
@@ -107,7 +154,15 @@ pub(crate) fn render_frame(
 
         match &entry.kind {
             EntryKind::Text(line) => {
-                out.push_str(line);
+                let highlighted = !query_lower.is_empty()
+                    && strip_ansi(line).to_lowercase().contains(&query_lower);
+                if highlighted {
+                    out.push_str("\x1b[7m");
+                    out.push_str(line);
+                    out.push_str("\x1b[0m");
+                } else {
+                    out.push_str(line);
+                }
                 out.push_str("\x1b[K\r\n");
                 rows_rendered += 1;
             }
@@ -195,10 +250,17 @@ pub(crate) fn render_frame(
     } else {
         ((top_entry + 1) * 100 / total).min(100)
     };
-    out.push_str(&format!(
-        "\x1b[{row};1H\x1b[2K\x1b[7m {pct}%\x1b[0m",
-        row = screen_rows
-    ));
+    if status_text.is_empty() {
+        out.push_str(&format!(
+            "\x1b[{row};1H\x1b[2K\x1b[7m {pct}%\x1b[0m",
+            row = screen_rows
+        ));
+    } else {
+        out.push_str(&format!(
+            "\x1b[{row};1H\x1b[2K\x1b[7m {pct}%  {status_text}\x1b[0m",
+            row = screen_rows
+        ));
+    }
 
     out
 }
@@ -342,7 +404,7 @@ mod tests {
         let doc = make_doc(vec![DocItem::Text("hello".to_string())]);
         let entries = layout(&doc, 8, 16);
         let mut transmitted = HashSet::new();
-        let frame = render_frame(&doc, &entries, 0, 24, 8, 16, &mut transmitted);
+        let frame = render_frame(&doc, &entries, 0, 24, 8, 16, &mut transmitted, "", "");
         assert!(frame.contains("\x1b[7m "));
     }
 
@@ -351,7 +413,7 @@ mod tests {
         let doc = make_doc(vec![DocItem::Text("hello".to_string())]);
         let entries = layout(&doc, 8, 16);
         let mut transmitted = HashSet::new();
-        let frame = render_frame(&doc, &entries, 0, 24, 8, 16, &mut transmitted);
+        let frame = render_frame(&doc, &entries, 0, 24, 8, 16, &mut transmitted, "", "");
         assert!(!frame.contains("\x1b[2J"));
         assert!(frame.contains("a=d,d=a"));
         assert!(frame.contains("\x1b[H"));
@@ -370,7 +432,7 @@ mod tests {
         let entries = layout(&doc, 8, 16);
         let mut transmitted = HashSet::new();
 
-        let frame = render_frame(&doc, &entries, 0, 24, 8, 16, &mut transmitted);
+        let frame = render_frame(&doc, &entries, 0, 24, 8, 16, &mut transmitted, "", "");
         // First frame: transmit (a=t) then place (a=p).
         assert!(frame.contains("a=t"));
         assert!(frame.contains("a=p,i=42"));
@@ -380,7 +442,7 @@ mod tests {
         let place_pos = frame.find("a=p").unwrap();
         assert!(transmit_pos < place_pos);
 
-        let frame2 = render_frame(&doc, &entries, 0, 24, 8, 16, &mut transmitted);
+        let frame2 = render_frame(&doc, &entries, 0, 24, 8, 16, &mut transmitted, "", "");
         // Second frame: placement only (no retransmission).
         assert!(frame2.contains("a=p,i=42"));
         assert!(!frame2.contains("a=t"));
@@ -404,7 +466,7 @@ mod tests {
 
         let mut transmitted = HashSet::new();
         // Skip the first image row (top_entry=1 → row_in_image=1).
-        let frame = render_frame(&doc, &entries, 1, 24, 8, 16, &mut transmitted);
+        let frame = render_frame(&doc, &entries, 1, 24, 8, 16, &mut transmitted, "", "");
         // Should transmit with y=16 (1 row * 16px), h=32 (2 visible rows × 16px),
         // and r=2 (2 visible display rows).
         assert!(frame.contains("y=16"));
@@ -435,7 +497,7 @@ mod tests {
         assert_eq!(entries.len(), 50);
 
         let mut transmitted = HashSet::new();
-        let frame = render_frame(&doc, &entries, 1, 51, 9, 18, &mut transmitted);
+        let frame = render_frame(&doc, &entries, 1, 51, 9, 18, &mut transmitted, "", "");
         assert!(frame.contains("y=30"), "expected y=30 in frame");
         assert!(frame.contains("h=1470"), "expected h=1470 in frame");
         assert!(frame.contains("r=49"), "expected r=49 in frame");
@@ -456,7 +518,7 @@ mod tests {
 
         let mut transmitted = HashSet::new();
         // Screen is 3 rows: 2 content + 1 status.  Image needs 3 rows → clipped to 2.
-        let frame = render_frame(&doc, &entries, 0, 3, 8, 16, &mut transmitted);
+        let frame = render_frame(&doc, &entries, 0, 3, 8, 16, &mut transmitted, "", "");
         assert!(frame.contains("h=32"));
         assert!(frame.contains("r=2"));
     }
@@ -484,7 +546,7 @@ mod tests {
         assert_eq!(entries.len(), 8);
 
         let mut transmitted = HashSet::new();
-        let frame = render_frame(&doc, &entries, 0, 10, 8, 16, &mut transmitted);
+        let frame = render_frame(&doc, &entries, 0, 10, 8, 16, &mut transmitted, "", "");
 
         // Image starts at content row 5 → terminal row 6 (1-based).
         // Rows 6, 7, 8 must each have a clear-line sequence (\x1b[K)
@@ -521,12 +583,47 @@ mod tests {
 
         let mut transmitted = HashSet::new();
         // Screen has 2 content rows → image is bottom-cropped to 2 rows.
-        let frame = render_frame(&doc, &entries, 0, 3, 8, 16, &mut transmitted);
+        let frame = render_frame(&doc, &entries, 0, 3, 8, 16, &mut transmitted, "", "");
         assert!(frame.contains("c=10"), "expected c=10 for natural-size image crop");
         assert!(frame.contains("r=2"), "expected r=2 for bottom crop");
 
         // Full image visible (no crop) — c= should still be present.
-        let frame2 = render_frame(&doc, &entries, 0, 24, 8, 16, &mut transmitted);
+        let frame2 = render_frame(&doc, &entries, 0, 24, 8, 16, &mut transmitted, "", "");
         assert!(frame2.contains("c=10"), "expected c=10 even without crop");
+    }
+
+    #[test]
+    fn render_frame_highlights_search_match() {
+        let doc = make_doc(vec![DocItem::Text("foo bar\nbaz qux".to_string())]);
+        let entries = layout(&doc, 8, 16);
+        let mut transmitted = HashSet::new();
+        let frame = render_frame(&doc, &entries, 0, 24, 8, 16, &mut transmitted, "bar", "");
+        // The matching line ("foo bar") should be wrapped in reverse-video.
+        assert!(frame.contains("\x1b[7mfoo bar\x1b[0m"), "expected highlighted match line");
+        // The non-matching line should not be highlighted.
+        assert!(!frame.contains("\x1b[7mbaz qux"));
+    }
+
+    #[test]
+    fn render_frame_no_highlight_when_no_query() {
+        let doc = make_doc(vec![DocItem::Text("hello world".to_string())]);
+        let entries = layout(&doc, 8, 16);
+        let mut transmitted = HashSet::new();
+        let frame = render_frame(&doc, &entries, 0, 24, 8, 16, &mut transmitted, "", "");
+        assert!(!frame.contains("\x1b[7mhello world"));
+    }
+
+    #[test]
+    fn strip_ansi_removes_csi_sequences() {
+        assert_eq!(strip_ansi("\x1b[1mhello\x1b[0m"), "hello");
+        assert_eq!(strip_ansi("\x1b[38;5;200mcolor\x1b[0m"), "color");
+        assert_eq!(strip_ansi("plain"), "plain");
+    }
+
+    #[test]
+    fn strip_ansi_removes_apc_sequences() {
+        // APC used by Kitty graphics protocol
+        let s = format!("text\x1b_Ga=t;\x1b\\more");
+        assert_eq!(strip_ansi(&s), "textmore");
     }
 }


### PR DESCRIPTION
Closes #4

## Summary
- Adds `/`, `?`, `n`, `N` search keybindings to the kitty pager, matching `less` behaviour
- `/query` jumps to the first match at or after the current position; `?query` searches backward
- `n` moves to the next match, `N` to the previous; matches wrap around

## Changes

**`kitty-pager/src/renderer.rs`**
- `strip_ansi()` — strips CSI/APC/OSC escape sequences to get plain text for matching
- `render_frame` gains `search_query` and `status_text` parameters; matched text lines are rendered with reverse-video highlight

**`kitty-pager/src/input.rs`**
- `SearchDirection`, `SearchState`, `InputMode` types for the search state machine
- `find_matches()` — case-insensitive search over text layout entries (image rows are skipped)
- `status_suffix()` — builds the status bar label (`/foo [2/3]`, `?bar_` prompt, `[No matches]`)
- Event loop handles `Normal` and `SearchInput` modes; match indices are recomputed on resize

The minus fallback pager already has built-in search (enabled via the `search` feature flag) and is unchanged.

## Testing
- [ ] `cargo test -p kitty-pager` — 27 tests, all pass
- [ ] In Kitty terminal: `cargo run -- README.md --pager`
  - Press `/` → search prompt appears in status bar
  - Type a word, Enter → jumps to first match, line highlighted
  - `n` / `N` → forward / backward navigation
  - `?` for backward search, `Esc` to cancel input
  - Query with no matches shows `[No matches]`