### PR TITLE
fix: use checked_div for scroll percentage; pin Rust toolchain

### DIFF
--- a/kitty-pager/src/renderer.rs
+++ b/kitty-pager/src/renderer.rs
@@ -190,11 +190,7 @@ pub(crate) fn render_frame(
 
     // Status bar.
     let total = layout.len();
-    let pct = if total == 0 {
-        100
-    } else {
-        ((top_entry + 1) * 100 / total).min(100)
-    };
+    let pct = ((top_entry + 1) * 100).checked_div(total).unwrap_or(100).min(100);
     out.push_str(&format!(
         "\x1b[{row};1H\x1b[2K\x1b[7m {pct}%\x1b[0m",
         row = screen_rows

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.94"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.94"
+components = ["clippy"]


### PR DESCRIPTION
Replaces manual division guard with checked_div to satisfy the new
clippy::manual_checked_ops lint introduced in Rust 1.95.

Adds rust-toolchain.toml pinned to 1.94 so CI and local development
use the same compiler, preventing future lint surprises from upstream
stable promotions.

https://claude.ai/code/session_01A9J5SnFsQugHRFWrRG8kZ1